### PR TITLE
fix: remove U+180E MONGOLIAN VOWEL SEPARATOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install with [npm](https://www.npmjs.com/):
 npm install @0x6b/textlint-rule-normalize-whitespaces
 ```
 
-This module requires Node.js >= 6.
+This module requires Node.js >= 16.0.0.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 |------------|---------------------------|
 | `U+00A0`   | NO-BREAK SPACE            |
 | `U+1680`   | OGHAM SPACE MARK          |
-| `U+180E`   | MONGOLIAN VOWEL SEPARATOR |
 | `U+2000`   | EN QUAD                   |
 | `U+2001`   | EM QUAD                   |
 | `U+2002`   | EN SPACE                  |
@@ -69,7 +68,7 @@ npm test
 
 ## References
 
-* [The Unicode (r) Standard Version 10.0 Core Specification](https://www.unicode.org/versions/Unicode10.0.0/ch06.pdf), Chapter 6 Writing Systems and Punctuation, Table 6-2. Unicode Space Characters
+* [The Unicode (r) Standard Version 15.0 Core Specification](https://www.unicode.org/versions/Unicode10.0.0/ch06.pdf), Chapter 6 Writing Systems and Punctuation, [Table 6-2. Unicode Space Characters](http://www.unicode.org/versions/Unicode15.0.0/ch06.pdf#G17548)
 * [Unicode spaces](http://jkorpela.fi/chars/spaces.html)
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@0x6b/textlint-rule-normalize-whitespaces",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@0x6b/textlint-rule-normalize-whitespaces",
-            "version": "1.1.4",
+            "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
                 "execall": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0x6b/textlint-rule-normalize-whitespaces",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "description": "textlint rule which normalizes whitespaces in the document.",
     "keywords": [
         "textlintrule"

--- a/src/SPACE_CHARACTERS.ts
+++ b/src/SPACE_CHARACTERS.ts
@@ -1,7 +1,6 @@
 const SPACE_CHARACTERS = [
     { code: "\u00a0", name: "NO-BREAK SPACE" },
     { code: "\u1680", name: "OGHAM SPACE MARK" },
-    { code: "\u180e", name: "MONGOLIAN VOWEL SEPARATOR" },
     { code: "\u2000", name: "EN QUAD" },
     { code: "\u2001", name: "EM QUAD" },
     { code: "\u2002", name: "EN SPACE" },


### PR DESCRIPTION
Since Unicode Standard Version 11.0, mongolian vowel separator is no longer classified as space characters.

